### PR TITLE
feat: Integrate Formspree for form submissions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,7 @@ DB_ENCRYPTION_KEY=7f9c3a2e1b8d9f4c7e6a5d3b9c2f0e1a
 
 
 FORCE_HTTPS=true
+
+# Formspree Endpoint
+# The URL for submitting the main form to Formspree.
+VITE_FORMSPREE_URL=


### PR DESCRIPTION
This commit refactors the form submission process to send all form data to a Formspree endpoint instead of the previous Netlify-based solution.

Key Changes:
- The form submission event listener in `script.js` has been updated to send a POST request to the URL specified in the `VITE_FORMSPREE_URL` environment variable.
- All form fields, including hidden and dropdown fields, are captured using the `FormData` API.
- The old submission logic for Netlify Forms and the custom `/submit-fan-permit` function has been removed.
- Upon successful submission to Formspree, the user is now redirected to `success.html`.
- The `VITE_FORMSPREE_URL` has been added to `.env.example` for discoverability.