### PR TITLE
Refactor: Use Formspree for form submission and fix deployment

### DIFF
--- a/server.js
+++ b/server.js
@@ -121,16 +121,12 @@ async function proxyNetlifyFunction(handler, req, res) {
 // Wire Netlify function handlers
 const sendOtpFn = require(path.join(__dirname, 'netlify/functions/send-otp.js'));
 const verifyOtpFn = require(path.join(__dirname, 'netlify/functions/verify-otp.js'));
-const submitFanPermitFn = require(path.join(__dirname, 'netlify/functions/submit-fan-permit.js'));
 
 app.post('/send-otp', (req, res) => proxyNetlifyFunction(sendOtpFn.handler || sendOtpFn, req, res));
 app.options('/send-otp', (req, res) => res.sendStatus(200));
 
 app.post('/verify-otp', (req, res) => proxyNetlifyFunction(verifyOtpFn.handler || verifyOtpFn, req, res));
 app.options('/verify-otp', (req, res) => res.sendStatus(200));
-
-app.post('/submit-fan-permit', (req, res) => proxyNetlifyFunction(submitFanPermitFn.handler || submitFanPermitFn, req, res));
-app.options('/submit-fan-permit', (req, res) => res.sendStatus(200));
 
 // Catch-all to serve index.html for any other request
 app.get('/*', function(req, res) {


### PR DESCRIPTION
This commit refactors the form submission process to use Formspree exclusively and resolves a deployment timeout on Render.

The following changes were made at the user's request:
- The form submission logic in `script.js` was configured to use the Formspree URL.
- The Netlify functions for form submission (`submit-form.js`, `submit-fan-permit.js`) were deleted.
- The corresponding redirect was removed from `netlify.toml`.
- Netlify-specific attributes were removed from the `<form>` tag in `index.html`.
- References to the deleted function were removed from `server.js` to prevent the server from crashing on startup, which resolved the deployment timeout.

The application is now configured to use Formspree for form submissions, and the deployment issue is resolved.