### PR TITLE
feat: Create professional success page with submission summary

### DIFF
--- a/script.js
+++ b/script.js
@@ -643,6 +643,10 @@ if (typeof document !== 'undefined') {
         console.log('Form submitted to Formspree successfully!');
         showToast('Form submitted successfully! Redirecting...', 'success');
 
+        // Store form data in sessionStorage for the success page
+        const dataToStore = Object.fromEntries(formData.entries());
+        sessionStorage.setItem('submissionData', JSON.stringify(dataToStore));
+
         // Redirect to the success page after a short delay
         setTimeout(() => {
           window.location.href = 'success.html';

--- a/success.html
+++ b/success.html
@@ -9,10 +9,9 @@
     <title>Subscription Successful - HYBE Fan-Permit 2025/2026</title>
     <meta
       name="description"
-      content="Thank you for joining the HYBE Fan-Permit 2025/2026! Get ready for exclusive K-pop access."
+      content="Thank you for joining the HYBE Fan-Permit 2025/2026! Here is a summary of your submission."
     />
-    <meta name="keywords" content="HYBE, K-pop, fan subscription, fan permit" />
-    <meta name="author" content="HYBE Corporation" />
+    <meta name="robots" content="noindex, nofollow" />
     <link
       href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
       rel="stylesheet"
@@ -23,6 +22,18 @@
     />
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
     <link rel="stylesheet" href="styles.css" />
+    <style>
+      .summary-card {
+        border-left: 5px solid #6a11cb;
+      }
+      .summary-key {
+        font-weight: 600;
+        color: #555;
+      }
+      .summary-value {
+        color: #333;
+      }
+    </style>
   </head>
   <body>
     <main>
@@ -31,33 +42,34 @@
           <div class="col-lg-8 col-md-10">
             <div
               class="card shadow-lg text-center"
-              style="max-width: 430px; margin: 5vh auto"
+              style="max-width: 600px; margin: 5vh auto"
             >
-              <div class="card-body">
+              <div class="card-body p-4 p-md-5">
                 <img
                   src="https://logotyp.us/file/hybe.svg"
                   alt="HYBE Logo"
-                  class="img-fluid mb-3 logo-pulse"
+                  class="img-fluid mb-4 logo-pulse"
                   style="max-width: 120px"
                 />
-                <div
-                  class="success-checkmark"
-                  style="font-size: 3.5rem; color: #4bb543; margin-bottom: 1rem"
-                >
-                  ✔
+                <div class="success-icon mb-3">
+                    <i class="bi bi-check-circle-fill text-success" style="font-size: 3.5rem;"></i>
                 </div>
-                <h1 class="h3 mb-2 fw-bold">Payment Successful!</h1>
-                <p class="lead mb-3">
-                  Your payment has been received.
+                <h1 class="h3 mb-2 fw-bold">Submission Successful!</h1>
+                <p class="lead mb-4">
+                  Thank you for subscribing to the HYBE Fan-Permit 2025/2026.
                 </p>
-                <p class="mb-4 text-muted">
-                  You’ll receive more details via email once it’s validated on the HYBE-PERMIT Subscription Database.<br />
-                  Thank you for joining the HYBE Fan-Permit 2025/2026.
+
+                <div id="submission-summary-container" class="text-start">
+                  <!-- Submission data will be injected here -->
+                </div>
+
+                <p class="mt-4 mb-4 text-muted">
+                  A confirmation email with your submission details has been sent to the address you provided. Please allow a few hours for validation against the HYBE-PERMIT Subscription Database.
                 </p>
                 <a
                   href="https://hybecorp.com"
                   class="btn btn-gradient btn-lg w-100 mt-2"
-                  >Continue to HYBECORP.COM</a
+                  >Return to HYBECORP.COM</a
                 >
               </div>
             </div>
@@ -164,6 +176,73 @@
         </div>
       </div>
     </footer>
+    <script>
+      document.addEventListener('DOMContentLoaded', () => {
+        const summaryContainer = document.getElementById('submission-summary-container');
+        const rawData = sessionStorage.getItem('submissionData');
+
+        if (rawData && summaryContainer) {
+          try {
+            const data = JSON.parse(rawData);
+
+            const card = document.createElement('div');
+            card.className = 'card summary-card bg-light p-3 mt-4';
+
+            const title = document.createElement('h5');
+            title.className = 'card-title mb-3';
+            title.textContent = 'Your Submission Summary';
+            card.appendChild(title);
+
+            const list = document.createElement('dl');
+            list.className = 'row';
+
+            // A helper function to format keys into readable labels
+            const formatKey = (key) => {
+              return key.replace(/-/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
+            };
+
+            // Define which fields to display and in what order
+            const fieldsToDisplay = [
+              'submission-id', 'full-name', 'email', 'phone', 'country', 'dob', 'gender',
+              'branch', 'group', 'artist', 'payment-type', 'payment-method', 'contact-method'
+            ];
+
+            fieldsToDisplay.forEach(key => {
+              if (data[key]) {
+                const dt = document.createElement('dt');
+                dt.className = 'col-sm-4 summary-key';
+                dt.textContent = formatKey(key);
+
+                const dd = document.createElement('dd');
+                dd.className = 'col-sm-8 summary-value';
+                dd.textContent = data[key];
+
+                list.appendChild(dt);
+                list.appendChild(dd);
+              }
+            });
+
+            card.appendChild(list);
+            summaryContainer.appendChild(card);
+
+            // Clear the data from session storage for security
+            sessionStorage.removeItem('submissionData');
+
+          } catch (error) {
+            console.error('Error parsing or displaying submission data:', error);
+            summaryContainer.innerHTML = '<p class="text-danger">Could not display submission summary due to an error.</p>';
+          }
+        } else if (summaryContainer) {
+          // Handle case where user lands here directly
+          summaryContainer.innerHTML = `
+            <div class="alert alert-warning text-center">
+              <p class="mb-0">No submission data found.</p>
+              <p class="mb-0">If you intended to submit a form, please <a href="index.html" class="alert-link">start here</a>.</p>
+            </div>
+          `;
+        }
+      });
+    </script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
   </body>
 </html>


### PR DESCRIPTION
This commit introduces a new professional success page that is displayed after a successful form submission.

The main changes are:
- Modified `script.js` to store the submitted form data in `sessionStorage` before redirecting to the success page.
- Overhauled `success.html` with a new, more professional design and layout.
- Added a script to `success.html` that dynamically generates a summary of the user's submission from the data stored in `sessionStorage`.
- The summary is displayed in a clean, card-based format.
- The data is cleared from `sessionStorage` after being displayed for privacy and security.
- A fallback message is shown if the success page is accessed directly without submission data.